### PR TITLE
Added secp521r1_kyber1024

### DIFF
--- a/draft-kwiatkowski-tls-ecdhe-kyber.md
+++ b/draft-kwiatkowski-tls-ecdhe-kyber.md
@@ -84,6 +84,7 @@ The table below lists all additional supported groups defined by this document a
 | secp256r1_kyber768  |         1248 |         1152 |            64 |
 | secp384r1_kyber768  |         1280 |         1184 |            80 |
 | secp384r1_kyber1024 |         1664 |         1664 |            80 |
+| secp521r1_kyber1024 |         1682 |         1682 |            98 |
 +---------------------+--------------+--------------+---------------|
 ~~~
 


### PR DESCRIPTION
Added secp521r1_kyber1024. 

But we may not need secp521r1_kyber1024 in there if this is just a temporary code point. I don't see a new for it right now. Maybe we should just push for just a final codepoint after Kyber is ratified, not now. 